### PR TITLE
feat: add UserGuid to HRUser for reliable lifecycle matching

### DIFF
--- a/EZSmartCardClient/EZSmartCardClient.csproj
+++ b/EZSmartCardClient/EZSmartCardClient.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Title>EZSmartCardClient</Title>
-    <Version>1.0.2</Version>
+    <Version>1.0.3</Version>
     <Authors>Keytos Security</Authors>
     <Copyright>Keytos Security</Copyright>
     <Description>EZSmartCard client is a package that allows you to automate some management API calls for your EZSmartCard Passwordless CMS</Description>

--- a/EZSmartCardClient/Models/HRUser.cs
+++ b/EZSmartCardClient/Models/HRUser.cs
@@ -36,7 +36,8 @@ public class HRUser
                 && Active == user.Active
                 && DocumentNumber == user.DocumentNumber
                 && DOB == user.DOB
-                && Country == user.Country;
+                && Country == user.Country
+                && UserGuid == user.UserGuid;
         }
         return false;
     }
@@ -61,6 +62,13 @@ public class HRUser
 
     [JsonPropertyName("Alias")]
     public string Alias { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Entra ID (Azure AD) object ID of the user. Populated when the user is sourced from
+    /// Entra so lifecycle reconciliation can match on this immutable ID instead of email.
+    /// </summary>
+    [JsonPropertyName("UserGuid")]
+    public string UserGuid { get; set; } = string.Empty;
 
     [JsonPropertyName("ManagerEmail")]
     public string ManagerEmail { get; set; } = string.Empty;


### PR DESCRIPTION
Add an Entra ID object ID (UserGuid) field to HRUser so user lifecycle reconciliation can match on the immutable Entra object ID instead of email, which can be renamed or differ only by casing. The field is serialized as "UserGuid" to round-trip with the server's DBHRInfoModel, included in Equals so a GUID change is treated as an update, and the existing-users read picks it up automatically via deserialization.

Bump package version to 1.0.3.